### PR TITLE
fix: Gemini API が使えなくても週次ページを作成する

### DIFF
--- a/src/application/use-cases/post-weekly-blog.ts
+++ b/src/application/use-cases/post-weekly-blog.ts
@@ -88,7 +88,17 @@ export class PostWeeklyBlogUseCase {
       })
       .join("\n\n");
 
-    const summary = await this.generativeAIProvider.generateContentEn(prompt);
+    let summary: string;
+    try {
+      summary = await this.generativeAIProvider.generateContentEn(prompt);
+    } catch (error) {
+      console.error(
+        "Failed to generate summary with generative AI. Creating page without summary.",
+        error,
+      );
+      summary =
+        "AI summary generation failed. Please check the related pages for details.";
+    }
 
     const content = weeklyTemplate.buildText(
       connectLinkText,

--- a/src/infrastructure/cli/weekly-cli.ts
+++ b/src/infrastructure/cli/weekly-cli.ts
@@ -16,8 +16,9 @@ const main = async () => {
     Deno.exit(1);
   }
   if (!geminiApiKey) {
-    console.error("Please set the GEMINI_API_KEY environment variable.");
-    Deno.exit(1);
+    console.warn(
+      "GEMINI_API_KEY is not set. The weekly page will be created without an AI-generated summary.",
+    );
   }
 
   const scrapboxRepository = new ScrapboxRepositoryImpl(sessionId);
@@ -27,7 +28,7 @@ const main = async () => {
     new CalculateAverageWakeUpTimeUseCase(scrapboxRepository, dateProvider);
   const calculateAverageSleepQualityUseCase =
     new CalculateAverageSleepQualityUseCase(scrapboxRepository, dateProvider);
-  const generativeAIProvider = new GenerativeAIProviderImpl(geminiApiKey);
+  const generativeAIProvider = new GenerativeAIProviderImpl(geminiApiKey ?? "");
   const postWeeklyBlogUseCase = new PostWeeklyBlogUseCase(
     scrapboxRepository,
     dateProvider,


### PR DESCRIPTION
## 概要
週次ページ作成時に Gemini API が動かない場合でも、ページが作成されるようにしました。

## 背景
これまでは summary 生成の Gemini 呼び出しが失敗すると例外が投げられ、ページ作成まで到達せず週次ページが作られませんでした。また `GEMINI_API_KEY` が未設定だと CLI が即終了していました。

## 変更内容
- `post-weekly-blog.ts`: AI summary 生成を try/catch で囲み、失敗時は空の summary をフォールバックとしてページ作成を続行
- `weekly-cli.ts`: `GEMINI_API_KEY` 未設定を fatal exit から warning に変更

これにより API エラー・レート制限・キー未設定のいずれの場合でも、平均起床時刻・睡眠の質・各種リンクを含む週次ページは summary 抜きで作成されます。

## テスト
- `deno check` 通過
- `deno test post-weekly-blog.test.ts` 全 4 件通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)